### PR TITLE
testbench.v: Allow overriding init.bin with a top-level parameter

### DIFF
--- a/src/test/ridecore/sim/testbench.v
+++ b/src/test/ridecore/sim/testbench.v
@@ -6,6 +6,7 @@ module testbench();
    parameter IMEM_INTERVAL = 2000;
    parameter SIM_CYCLE = 10000000;
    parameter SIM_TIME = SIM_CYCLE * CLK_CYCLE_TIME * 2;
+   parameter init_file = "../bin/init.bin";
 
    reg [31:0] 			CLK_CYCLE;
    reg 				clk;
@@ -64,9 +65,9 @@ module testbench();
 	 rv.pipe.pipe_if.gsh.prhisttbl.pht1.mem[i] = 3;
       end
       
-      fp = $fopen("../bin/init.bin", "rb");
+      fp = $fopen(init_file, "rb");
       temp = $fread(rv.instmemory.mem, fp);
-      fp = $fopen("../bin/init.bin", "rb");
+      fp = $fopen(init_file, "rb");
       temp = $fread(rv.datamemory.mem, fp);
 
       for (i = 0 ; i < 512 ; i = i + 1) begin


### PR DESCRIPTION
Hi,

I've started adding FuseSoC support for ridecore. This patch makes it easier to override the init memory from command-line.

You can test it by installing FuseSoC (https://github.com/olofk/fusesoc) and run `fusesoc sim ridecore --init_file=/path/to/init.bin`. Works with icarus verilog and modelsim so far
